### PR TITLE
added support for varied model deployment name in aoai healthcheck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ obj
 __blobstorage__
 __queuestorage__
 __azurite_db*__.json
+
+# local VSCode IDE config
+.vscode

--- a/FwdProxy/handleAOAIHealthCheck.js
+++ b/FwdProxy/handleAOAIHealthCheck.js
@@ -29,7 +29,6 @@ module.exports = async function (context, req) {
         temperature: 0.5,
         top_p: 0.5,
         max_tokens: 300,
-
       };
       const postData = JSON.stringify(healthcheckbody);
       context.log('newPath = ' + newPath);
@@ -61,6 +60,7 @@ module.exports = async function (context, req) {
                 status: res2.statusCode 
             };  
             context.res = response;  
+            context.log("aoai healthcheck response: " + data)
             resolve();  
         });  
       }); 
@@ -87,8 +87,7 @@ module.exports = async function (context, req) {
       });  
 
       req2.write(postData);  
-      req2.end();         
-
+      req2.end();
         
     }catch(err){
       console.log(err);

--- a/FwdProxy/handleAOAIHealthCheck.js
+++ b/FwdProxy/handleAOAIHealthCheck.js
@@ -2,15 +2,18 @@ require('dotenv').config();
 const https = require('https');
 const newhostname = process.env.AOAI_HOSTNAME;
 const apiKey = process.env.AOAI_OUTAPIKEY;
+var modelname = process.env.AOAI_MODELNAME;
+var healthcheckPrompt = process.env.AOAI_HEALTHCHECK_PROMPT;
 
-  
-module.exports = async function (context, req) {  
-  return new Promise((resolve, reject) => {      
+module.exports = async function (context, req) {
+  return new Promise((resolve, reject) => { 
     try{
-      const modelname = context.bindingData.modelname;
       const openai = context.bindingData.openai;
       const deployments = context.bindingData.deployments;
       const apiversion = (req.query['api-version']);
+
+      modelname = modelname || context.bindingData.modelname;
+      healthcheckPrompt = healthcheckPrompt || 'hi, I am healthcheck'
 
       context.log('aoai_healthcheck');  
       const newPath =  '/' + openai + '/' + deployments + '/' + modelname + '/chat/completions?api-version=' + apiversion;        
@@ -20,13 +23,13 @@ module.exports = async function (context, req) {
         messages: [
           {
             role: 'user',
-            content: 'hi, I am healthcheck'
+            content: healthcheckPrompt
           }
         ],
         temperature: 0.5,
         top_p: 0.5,
         max_tokens: 300,
-    
+
       };
       const postData = JSON.stringify(healthcheckbody);
       context.log('newPath = ' + newPath);

--- a/FwdProxy/handleAOAIHealthCheck.js
+++ b/FwdProxy/handleAOAIHealthCheck.js
@@ -2,12 +2,12 @@ require('dotenv').config();
 const https = require('https');
 const newhostname = process.env.AOAI_HOSTNAME;
 const apiKey = process.env.AOAI_OUTAPIKEY;
-var modelname = process.env.AOAI_MODELNAME;
 var healthcheckPrompt = process.env.AOAI_HEALTHCHECK_PROMPT;
 
 module.exports = async function (context, req) {
   return new Promise((resolve, reject) => { 
     try{
+      const modelname = context.bindingData.modelname;
       const openai = context.bindingData.openai;
       const deployments = context.bindingData.deployments;
       const apiversion = (req.query['api-version']);

--- a/FwdProxy/handlePostMessage.js
+++ b/FwdProxy/handlePostMessage.js
@@ -4,17 +4,16 @@ const newhostname = process.env.AOAI_HOSTNAME;
 const apiKey = process.env.AOAI_OUTAPIKEY;
 const inapiKey = process.env.AOAI_INAPIKEY;
 
-var modelname = process.env.AOAI_MODELNAME;
   
 module.exports = async function (context, req) {  
   return new Promise((resolve, reject) => {      
     try{
+      const modelname = context.bindingData.modelname;
       const openai = context.bindingData.openai;
       const deployments = context.bindingData.deployments;
       const apiversion = (req.query['api-version']);
       var apiname = context.bindingData.apiname;
-      modelname = modelname || context.bindingData.modelname;
-
+      
     context.log('post message');  
     if (req.headers['api-key'] != inapiKey){
         throw new Error('Invalid apikey');

--- a/FwdProxy/handlePostMessage.js
+++ b/FwdProxy/handlePostMessage.js
@@ -3,15 +3,17 @@ const https = require('https');
 const newhostname = process.env.AOAI_HOSTNAME;
 const apiKey = process.env.AOAI_OUTAPIKEY;
 const inapiKey = process.env.AOAI_INAPIKEY;
+
+var modelname = process.env.AOAI_MODELNAME;
   
 module.exports = async function (context, req) {  
   return new Promise((resolve, reject) => {      
     try{
-      const modelname = context.bindingData.modelname;
       const openai = context.bindingData.openai;
       const deployments = context.bindingData.deployments;
       const apiversion = (req.query['api-version']);
       var apiname = context.bindingData.apiname;
+      modelname = modelname || context.bindingData.modelname;
 
     context.log('post message');  
     if (req.headers['api-key'] != inapiKey){

--- a/FwdProxy/index.js
+++ b/FwdProxy/index.js
@@ -20,7 +20,7 @@ module.exports = async function (context, req) {
     await handleAOAIHealthCheck(context, req); 
 
   } else {
-    context.log('Uncategorized request: ' + req);  
+    context.log('Uncategorized request: ' + JSON.stringify(req));  
     context.res = { status: 404 ,body: 'Resource Not Found'  }; 
   }
 };

--- a/FwdProxy/index.js
+++ b/FwdProxy/index.js
@@ -20,7 +20,7 @@ module.exports = async function (context, req) {
     await handleAOAIHealthCheck(context, req); 
 
   } else {
-    context.log('else....');  
+    context.log('Uncategorized request: ' + req);  
     context.res = { status: 404 ,body: 'Resource Not Found'  }; 
   }
 };

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 
 # Boost up 4x Request per minute for your AOAI Resources
-![concept1](https://github.com/denlai-mshk/aoai-fwdproxy-funcapp/blob/main/screenshots/concept1.png)
+![concept1](screenshots/concept1.png)
 
 ## Fully utilize AOAI quotas and limits
-![limit](https://github.com/denlai-mshk/aoai-fwdproxy-funcapp/blob/main/screenshots/limit.png)
+![limit](screenshots/limit.png)
 
 As at 12 June 2023, **one subscription** can provision **30 AOAI resources per region**, sharing the same TPM and RPM limits. For example, you can allocate 3 deployment instances of GPT-35-Turbo with 80K TPM/480 RPM each to utilize the whole TPM/RPM limits for one region.
 
-![limit2](https://github.com/denlai-mshk/aoai-fwdproxy-funcapp/blob/main/screenshots/newlimit.png)
+![limit2](screenshots/newlimit.png)
 
 As at June 2023, there are four regional Cognitive services that support Azure OpenAI -*EastUS, South Cental US, West Europe and France Central* which allows for a **maximium 120 instances** of the same AOAI model can be provisoned across these four regions. This means you can achieve up to *(1440x4/60)* = **maximium 96 request per second** for your ChatGPT model per subscription. If this is still not enough to meet your production workload requirements, you can consider getting additional subscriptions to create an AOAI resources RAID.
 
@@ -18,14 +18,14 @@ As at June 2023, there are four regional Cognitive services that support Azure O
 You can apply for quota increase requests by filling out forms, but this may not be the most practical solution as it won't give you access to the additional resources right away. What if your AOAI service demand continues to grow? Utilizing your existing quotas is the more practical solution. Remember, you have a maximum of 120 model instances across 4 regions with 4 times quotas and limits for 1 subscription. If you don't have concerns about cross-region networking cost, spanning across regions is the fastest way to get your production rollout up and running.
 
 ## Load balancing multiple AOAI Resources 
-![concept3](https://github.com/denlai-mshk/aoai-fwdproxy-funcapp/blob/main/screenshots/concept3.png)
+![concept3](screenshots/concept3.png)
 
 The common practice is to use Azure Application Gateway (AppGW) to perform a round-robin traffic distribution, alongside Azure DDoS service to protect your cloud telemetry. However, the rewrite rule capability of AppGW cannot rewrite the API key immediately after an AOAI resource is designated as a backend target. Therefore, a forward proxy server for each particular AOAI endpoint needs to be added to change the corresponding API key. As a result, you will need to provision three Function Apps per region to serve as the forward proxy servers. Don’t worry, these Function Apps can share the same App Service Plan. 
 
 
 
 ## Transforming your API with actual AOAI endpoints
-![concept2](https://github.com/denlai-mshk/aoai-fwdproxy-funcapp/blob/main/screenshots/concept2.png)
+![concept2](screenshots/concept2.png)
 
 From this diagram, it is clear that all Apps will direct their API calls to a single AppGW endpoint (either via public IP or domain name). This endpoint will have a shorter URI path and an internal API key, granted by your AOAI admin, for user authentication. Access control of which authenticated parties can access the Function Apps can be dynamically controlled by this internal API key. Once AppGW has distributed the incoming API requests to the different Function Apps, it will convert the API requests to the actual AOAI API requests, with the actual AOAI domain name, longer URI path, and actual API key in the AUTH header section. 
 - **shorter URI path** API caller only need to provides model-name,model-api, apiversion.
@@ -52,13 +52,13 @@ From this diagram, it is clear that all Apps will direct their API calls to a si
   - only need one per region to support multiple Function Apps
 
 ## Responsible AI (RAI) Orchestration in your tenant
-![rai](https://github.com/denlai-mshk/aoai-fwdproxy-funcapp/blob/main/screenshots/rai.png)
+![rai](screenshots/rai.png)
 
 While most of enterprise customers likely opt-out of the Microsoft RAI mitigation approach ([Content Filtering and Abuse Monitoring](https://learn.microsoft.com/en-us/legal/cognitive-services/openai/data-privacy?context=%2Fazure%2Fcognitive-services%2Fopenai%2Fcontext%2Fcontext#how-can-a-customer-verify-if-logging-for-abuse-monitoring-is-off)). 
 To comply with the [Azure OpenAI Code of Conduct and Terms of Use](https://learn.microsoft.com/en-us/legal/cognitive-services/openai/code-of-conduct), the customer must build their own RAI infrastructure. Leveraging the above architecture pattern can give you greater control and governance over your Function Apps. For instance, 
 1. Incoming API request bodies without a 'User' or unregistered username can be rejected. 
 
-![user](https://github.com/denlai-mshk/aoai-fwdproxy-funcapp/blob/main/screenshots/user.png)
+![user](screenshots/user.png)
 
 2. User prompts can be sent to Azure AI Content Safety for offensive content detection and filtering before reaching the AOAI resources. 
 3. The username and corresponding content can be logged in CosmosDB if the prompt is non-compliant.
@@ -67,7 +67,7 @@ To comply with the [Azure OpenAI Code of Conduct and Terms of Use](https://learn
 ## Function App Configuration
 1. [Create your first function in the Azure portal](https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-function-app-portal)
 
-![createfuncapp](https://github.com/denlai-mshk/aoai-fwdproxy-funcapp/blob/main/screenshots/createfuncapp.png)
+![createfuncapp](screenshots/createfuncapp.png)
 
 2. After Function App is created, Left blade > Configuration > Add Applilcation Settings > **Save**
 ```javascript    
@@ -75,13 +75,13 @@ To comply with the [Azure OpenAI Code of Conduct and Terms of Use](https://learn
     AOAI_INAPIKEY = {your internal apiKey for authenticated user}
     AOAI_OUTAPIKEY = {actual AOAI apikey}
 ```
-![appconfig](https://github.com/denlai-mshk/aoai-fwdproxy-funcapp/blob/main/screenshots/appconfig.png)
+![appconfig](screenshots/appconfig.png)
 
 3. Left blade > Health check > add path > **Save**
 ```javascript  
 /api/FwdProxy/openai/deployments/health/check
 ```
-![funchealth](https://github.com/denlai-mshk/aoai-fwdproxy-funcapp/blob/main/screenshots/funchealth.png)
+![funchealth](screenshots/funchealth.png)
 
 ## Function App Forward Proxy Implementation
 1. Please clone this repo into your local folder
@@ -92,7 +92,7 @@ git clone https://github.com/denlai-mshk/aoai-fwdproxy-funcapp.git
 3. Install - extension: Azure Function, Azure Account
 4. Left blade , click Azure icon > Workspace > mouse over the deploy icon
 
-![deploy](https://github.com/denlai-mshk/aoai-fwdproxy-funcapp/blob/main/screenshots/deploy.png)
+![deploy](screenshots/deploy.png)
 
 5. SSO your Microsoft account, select Azure subscription and Function App you just created.
 
@@ -104,25 +104,25 @@ git clone https://github.com/denlai-mshk/aoai-fwdproxy-funcapp.git
 5. Add 1 rewrite ruleset (extensionschatcompletion_99/chatcompletion_100/otherapi_101/healthcheck_102) bind with Routing rule
 6. AppGW inbound and outbound are 443 port for TLS/SSL
 
-![backendpool](https://github.com/denlai-mshk/aoai-fwdproxy-funcapp/blob/main/screenshots/backendpool.png)
+![backendpool](screenshots/backendpool.png)
 
-![backendsetting](https://github.com/denlai-mshk/aoai-fwdproxy-funcapp/blob/main/screenshots/backendsetting.png)
+![backendsetting](screenshots/backendsetting.png)
 
-![rule](https://github.com/denlai-mshk/aoai-fwdproxy-funcapp/blob/main/screenshots/rule.png)
+![rule](screenshots/rule.png)
 
-![healthprobe](https://github.com/denlai-mshk/aoai-fwdproxy-funcapp/blob/main/screenshots/healthprobe.png)
+![healthprobe](screenshots/healthprobe.png)
 
-![Listener](https://github.com/denlai-mshk/aoai-fwdproxy-funcapp/blob/main/screenshots/listener.png)
+![Listener](screenshots/listener.png)
 
-![rewrite000](https://github.com/denlai-mshk/aoai-fwdproxy-funcapp/blob/main/screenshots/rewrite000.png)
+![rewrite000](screenshots/rewrite000.png)
 
-![rewrite99](https://github.com/denlai-mshk/aoai-fwdproxy-funcapp/blob/main/screenshots/rewrite99.png)
+![rewrite99](screenshots/rewrite99.png)
 
-![rewrite100](https://github.com/denlai-mshk/aoai-fwdproxy-funcapp/blob/main/screenshots/rewrite100.png)
+![rewrite100](screenshots/rewrite100.png)
 
-![rewrite101](https://github.com/denlai-mshk/aoai-fwdproxy-funcapp/blob/main/screenshots/rewrite101.png)
+![rewrite101](screenshots/rewrite101.png)
 
-![rewrite102](https://github.com/denlai-mshk/aoai-fwdproxy-funcapp/blob/main/screenshots/rewrite102.png)
+![rewrite102](screenshots/rewrite102.png)
 
 - **extensionschatcompletion(99)**
   ```javascript  
@@ -195,15 +195,15 @@ git clone https://github.com/denlai-mshk/aoai-fwdproxy-funcapp.git
 ## How to test with PostMan
 Well-known API tester Postman released OpenAI API profile for free. Get that [over here](https://www.postman.com/devrel/workspace/openai/documentation/13183464-90abb798-cb85-43cb-ba3a-ae7941e968da)
 
-![postman](https://github.com/denlai-mshk/aoai-fwdproxy-funcapp/blob/main/screenshots/postman.png)
+![postman](screenshots/postman.png)
 
 In postman, pass your internal apikey in auth header
 
-![postmansend](https://github.com/denlai-mshk/aoai-fwdproxy-funcapp/blob/main/screenshots/postmansend.png)
+![postmansend](screenshots/postmansend.png)
 
 ## Advanced Health Checking
 
-![advhealthcheck](https://github.com/denlai-mshk/aoai-fwdproxy-funcapp/blob/main/screenshots/advhealthcheck.png)
+![advhealthcheck](screenshots/advhealthcheck.png)
 
 Based on observations and customer feedback, it has been noticed that your API may occasionally respond with HTTP 5xx errors. These errors are typically caused by the AOAI endpoints being overwhelmed due to high traffic. To address this issue, we can implement a more intelligent health check logic. This logic will enable your AppGW to automatically and temporarily remove any AOAI endpoint from the backend pool if it receives a 5xx response during the health check. During the next health check cycle, if the endpoint responds with a 200 status, AppGW will add it back to the backend pool. This approach ensures that only healthy endpoints are utilized by your application.
 
@@ -221,7 +221,7 @@ Lastly, when deploying this advanced health checking capability, it is important
 
 
 ## Go for Production To-Do List
-![refarch](https://github.com/denlai-mshk/aoai-fwdproxy-funcapp/blob/main/screenshots/refarch.png)
+![refarch](screenshots/refarch.png)
 
 - It is highly recommended to adopt the Hub-Spoke best practices in order to centralize all AOAI resources within the hub subscription. This approach provides several benefits, including centralized Responsible AI governance and enhanced usage control such as user quotas. By centralizing the AOAI resources, you can effectively manage and monitor the AI capabilities in a more streamlined and controlled manner. This ensures that responsible AI practices are implemented consistently across the organization and allows for better control over resource allocation and usage.Responsible AI governance as well as usage control like user quotas. 
 - Consider provisioning the Function App in VNET Injection mode for security. 


### PR DESCRIPTION
aimed to address #1 

Suggested modifications to README if this code update can be adopted:

1. Two additional variables can be added to the Functional App configuration. i.e.:
    - AOAI_MODELNAME, the model name (aka. deployment name) in the bounded AOAI instance. Used for advanced health check only.
    - AOAI_HEALTHCHECK_PROMPT, the prompt used for advanced health check. E.g. we could use "reply Y if alive" to reduce token usage (a bit or a lot over time)